### PR TITLE
Chore: Move things that should have been installed to dependencies vs. dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "inquirer": "^0.12.0",
+    "ramda": "^0.21.0",
+    "slug": "^0.9.1",
     "yeoman-generator": "^0.22.0",
     "yosay": "^1.0.2"
   },
@@ -44,8 +46,6 @@
     "gulp-mocha": "^2.0.0",
     "gulp-nsp": "^2.1.0",
     "gulp-plumber": "^1.0.0",
-    "ramda": "^0.20.1",
-    "slug": "^0.9.1",
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"
   },


### PR DESCRIPTION
These libs should have been installed to `dependencies` and not `devDependencies`. Moved 'em!