### PR TITLE
Feature: Add `project.yaml` template

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -158,6 +158,12 @@ module.exports = class extends yeoman.Base {
       `${dest}/README.md`,
       this.props
     );
+
+    this.fs.copyTpl(
+      `${templates}/project.yaml`,
+      `${dest}/src/data/project.yaml`,
+      this.props
+    );
   }
 
   /**

--- a/generators/app/templates/project.yaml
+++ b/generators/app/templates/project.yaml
@@ -1,0 +1,1 @@
+title: <%= title %>


### PR DESCRIPTION
This PR is the second step in addressing https://github.com/cloudfour/drizzle/issues/44.

Changes include:
- Add a `project.yaml` template file
- Add logic to copy the new `project.yaml` file to proper destination location
- Bump submodule to latest `drizzle`

cc: @erikjung @tylersticka 